### PR TITLE
Change to swiftmailer6 compliant initialization

### DIFF
--- a/src/FondOfSpryker/Zed/Mail/MailDependencyProvider.php
+++ b/src/FondOfSpryker/Zed/Mail/MailDependencyProvider.php
@@ -24,7 +24,7 @@ class MailDependencyProvider extends SprykerMailDependencyProvider
     protected function addMailer(Container $container): Container
     {
         $container[static::MAILER] = function () {
-            $transport = Swift_SmtpTransport::newInstance(
+            $transport = new Swift_SmtpTransport(
                 $this->getConfig()->getSmtpHost(),
                 $this->getConfig()->getSmtpPort()
             );


### PR DESCRIPTION
`newInstance` has been removed from switfmailer classes with version >=6.

See https://github.com/swiftmailer/swiftmailer/blob/master/CHANGES for reference 

